### PR TITLE
Add tests for uncovered methods

### DIFF
--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -1,10 +1,10 @@
 #include "storage_manager.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 #include "utils/assert.hpp"
 

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -4,8 +4,8 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "storage/table.hpp"
 #include "types.hpp"

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -5,9 +5,9 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unordered_map>
 
 #include "base_segment.hpp"
 #include "chunk.hpp"

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -27,6 +27,11 @@ ChunkOffset ValueSegment<T>::size() const {
   return _values.size();
 }
 
+template <typename T>
+const std::vector<T>& ValueSegment<T>::values() const {
+  return _values;
+}
+
 EXPLICITLY_INSTANTIATE_DATA_TYPES(ValueSegment);
 
 }  // namespace opossum

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -27,6 +27,22 @@ TEST_F(StorageStorageManagerTest, GetTable) {
   EXPECT_THROW(sm.get_table("third_table"), std::exception);
 }
 
+TEST_F(StorageStorageManagerTest, TableNames) {
+  auto& sm = StorageManager::get();
+  std::vector table_names = sm.table_names();
+  EXPECT_TRUE(std::find(table_names.begin(), table_names.end(), "first_table") != table_names.end());
+  EXPECT_TRUE(std::find(table_names.begin(), table_names.end(), "second_table") != table_names.end());
+}
+
+TEST_F(StorageStorageManagerTest, PrintTable) {
+  auto& sm = StorageManager::get();
+  std::ostringstream stream;
+  sm.print(stream);
+  std::string printed = stream.str();
+  EXPECT_TRUE(printed.find("second_table, 0, 0, 1") != std::string::npos);
+  EXPECT_TRUE(printed.find("first_table, 0, 0, 1") != std::string::npos);
+}
+
 TEST_F(StorageStorageManagerTest, DropTable) {
   auto& sm = StorageManager::get();
   sm.drop_table("first_table");

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -53,6 +53,8 @@ TEST_F(StorageTableTest, RowCount) {
 TEST_F(StorageTableTest, GetColumnName) {
   EXPECT_EQ(t.column_name(ColumnID{0}), "col_1");
   EXPECT_EQ(t.column_name(ColumnID{1}), "col_2");
+  EXPECT_EQ(t.column_names()[0], "col_1");
+  EXPECT_EQ(t.column_names()[1], "col_2");
   // TODO(anyone): Do we want checks here?
   // EXPECT_THROW(t.column_name(ColumnID{2}), std::exception);
 }

--- a/src/test/storage/value_segment_test.cpp
+++ b/src/test/storage/value_segment_test.cpp
@@ -33,14 +33,18 @@ TEST_F(StorageValueSegmentTest, AddValueOfSameType) {
   EXPECT_EQ(double_value_segment.size(), 1u);
 }
 
-TEST_F(StorageValueSegmentTest, GetValue) {
-  /* Somehow does not work
+TEST_F(StorageValueSegmentTest, GetValues) {
+  int_value_segment.append(3);
+  EXPECT_EQ(int_value_segment.values().at(0), 3);
   EXPECT_EQ(type_cast<int>(int_value_segment[ChunkOffset{0}]), 3);
 
+  string_value_segment.append("Hello");
+  EXPECT_EQ(string_value_segment.values().at(0), "Hello");
   EXPECT_EQ(type_cast<std::string>(string_value_segment[ChunkOffset{0}]), "Hello");
 
+  double_value_segment.append(3.14);
+  EXPECT_EQ(double_value_segment.values().at(0), 3.14);
   EXPECT_EQ(type_cast<double>(double_value_segment[ChunkOffset{0}]), 3.14);
-   */
 }
 
 TEST_F(StorageValueSegmentTest, AddValueOfDifferentType) {

--- a/src/test/storage/value_segment_test.cpp
+++ b/src/test/storage/value_segment_test.cpp
@@ -33,6 +33,16 @@ TEST_F(StorageValueSegmentTest, AddValueOfSameType) {
   EXPECT_EQ(double_value_segment.size(), 1u);
 }
 
+TEST_F(StorageValueSegmentTest, GetValue) {
+  /* Somehow does not work
+  EXPECT_EQ(type_cast<int>(int_value_segment[ChunkOffset{0}]), 3);
+
+  EXPECT_EQ(type_cast<std::string>(string_value_segment[ChunkOffset{0}]), "Hello");
+
+  EXPECT_EQ(type_cast<double>(double_value_segment[ChunkOffset{0}]), 3.14);
+   */
+}
+
 TEST_F(StorageValueSegmentTest, AddValueOfDifferentType) {
   int_value_segment.append(3.14);
   EXPECT_EQ(int_value_segment.size(), 1u);


### PR DESCRIPTION
Line coverages:
- `chunk.cpp: 100%`
- `storage_manager.cpp: 100%`
- `table.cpp: 97.1%`
- `value_segment.cpp: 100%`

For `table.cpp` I did not know how to test the `const` overload function `const Chunk& Table::get_chunk(ChunkID chunk_id) const { return *_chunks[chunk_id]; }`, that's why it is not 100%.

For `value_segment.cpp` I also implemented `values()`, I guess we missed that somehow.

Fixes #2 
